### PR TITLE
feat(prometheus): add air-gap installation like other TDP services

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Ansible collection to deploy a monitoring stack on top of a [TDP](https://github
 
 For now, relies on [cloudalchemy.prometheus](https://github.com/cloudalchemy/ansible-prometheus) and [cloudalchemy.grafana](https://github.com/cloudalchemy/ansible-grafana) to deploy Prometheus and Grafana.
 
+## Download binaries
+
+Binaries must be present inside `files` directory located next to launched playbooks. They can be found here:
+
+- Prometheus: https://github.com/prometheus/prometheus/releases
+
 ## Using in tdp-getting-started
 
 ```sh

--- a/roles/prometheus/server/tasks/install.yml
+++ b/roles/prometheus/server/tasks/install.yml
@@ -6,6 +6,51 @@
     name: cloudalchemy.prometheus
     tasks_from: preflight
 
+- name: Upload {{ prometheus_dist_file }}
+  copy:
+    src: files/{{ prometheus_dist_file }}
+    dest: "{{ binaries_upload_dir }}"
+    owner: root
+    group: root
+    mode: "644"
+  diff: false
+
+- name: Ensure {{ prometheus_root_dir }} exists
+  file:
+    path: "{{ prometheus_root_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "755"
+
+- name: Extract {{ prometheus_dist_file }}
+  unarchive:
+    src: "{{ binaries_upload_dir }}/{{ prometheus_dist_file }}"
+    dest: "{{ prometheus_root_dir }}"
+    owner: root
+    group: root
+    mode: "755"
+    remote_src: true
+    creates: "{{ prometheus_root_dir }}/{{ prometheus_release }}"
+
+- name: Create symbolic link to Prometheus installation
+  file:
+    src: "{{ prometheus_root_dir }}/{{ prometheus_release }}"
+    dest: "{{ prometheus_install_dir }}"
+    state: link
+
+# In role cloudalchemy.prometheus, a variable "_prometheus_binary_install_dir" is used
+# to define binaries install directory but "tdp_vars" can not override it because
+# the variable is located inside role "vars" directory
+- name: Symlink prometheus and promtool binaries
+  file:
+    src: "{{ prometheus_install_dir }}/{{ item }}"
+    dest: "{{ prometheus_binary_install_dir }}/{{ item }}"
+    state: link
+  loop:
+    - prometheus
+    - promtool
+
 - include_role:
     name: cloudalchemy.prometheus
     tasks_from: install

--- a/tdp_vars_defaults/prometheus/prometheus.yml
+++ b/tdp_vars_defaults/prometheus/prometheus.yml
@@ -2,22 +2,31 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-prometheus_start_on_boot: no
+# Prometheus version
+prometheus_version: 2.37.6
+prometheus_release: "prometheus-{{ prometheus_version }}.linux-amd64"
+prometheus_dist_file: "{{ prometheus_release }}.tar.gz"
 
-prometheus_version: 2.38.0
-prometheus_selinux_packages:
-  # For RHEL 7
-  - libselinux-python
-  - policycoreutils-python
-  # For RHEL 8
-  # - python3-libselinux
-  # - python3-policycoreutils
+# Prometheus installation directory
+prometheus_root_dir: /opt/tdp_observability
+prometheus_install_dir: "{{ prometheus_root_dir }}/prometheus"
+# _prometheus_binary_install_dir is used inside cloudalchemy.prometheus
+# but with "tdp_vars" we can not override it
+prometheus_binary_install_dir: "/usr/local/bin"
 
-# Prometheus directories
+# Skip cloudalchemy.prometheus install, we perform air-gap installation ourself
+prometheus_skip_install: true
+
+# Prometheus configuration directories
 prometheus_config_dir: /etc/prometheus
 prometheus_certs_dir: "{{ prometheus_config_dir }}/certs"
 prometheus_static_targets_dir: "{{ prometheus_config_dir }}/file_sd"
+
+# Prometheus data directory
 prometheus_db_dir: /var/lib/prometheus
+
+# Selinux packages are not needed, prometheus is unconfined
+prometheus_selinux_packages: []
 
 # Prometheus web configuration
 prometheus_web_listen_address: "0.0.0.0:{{ prometheus_web_port }}"
@@ -131,3 +140,6 @@ prometheus_relabels:
     regex: "(.*):.*"
     target_label: "instance"
     replacement: "${1}"
+
+# Prometheus service start on boot policies
+prometheus_start_on_boot: false


### PR DESCRIPTION
Prometheus binaries archive must be present on Ansible controller.

<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #33 
Fixes #29 

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
