### PR TITLE
Changed version names of loki and promtail

### DIFF
--- a/tdp_vars_defaults/loki/loki_promtail.yml
+++ b/tdp_vars_defaults/loki/loki_promtail.yml
@@ -9,7 +9,7 @@ promtail_secondary_groups:
   - "{{ hadoop_group }}"
   - node-exporter
 # promtail version
-promtail_release: promtail-2.7.2-linux-amd64
+promtail_release: promtail-linux-amd64
 promtail_dist_file: "{{ promtail_release }}.zip"
 
 # promtail installation directory

--- a/tdp_vars_defaults/loki/loki_server.yml
+++ b/tdp_vars_defaults/loki/loki_server.yml
@@ -7,7 +7,7 @@ loki_user: loki
 loki_group: "{{ hadoop_group }}"
 
 # loki version
-loki_release: loki-2.7.2-linux-amd64
+loki_release: loki-linux-amd64
 loki_dist_file: "{{ loki_release }}.zip"
 
 # loki installation directory


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

The release name `loki-2.7.2-linux-amd64` and `promtail-2.7.2-linux-amd64` do not exist anymore in the official release [repository](https://github.com/grafana/loki/releases/tag/v2.7.2). they should correspond to the version `loki-linux-amd64` and `promtail-linux-amd64` under the tag `2.7.2`. These two releases have been tested in a cluster and they work.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
