### PR TITLE
fix: remove uneeded ansible-galaxy call from ci setup

### DIFF
--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -22,7 +22,6 @@ setup_python_venv() {
   (
     source "${PYTHON_VENV}/bin/activate"
     pip install -r dev/requirements.txt
-    ansible-galaxy collection install community.general
   )
   return 0
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes CI. I get an error when installing collection on the CI (reproducible using dev/setup.sh)

Error being:

[WARNING]: Skipping Galaxy server https://galaxy.ansible.com. Got an unexpected error when getting available versions of collection community.general: Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/': HTTPSConnection.__init__() got an unexpected keyword argument 'cert_file'.
HTTPSConnection.__init__() got an unexpected keyword argument 'cert_file'
ERROR! Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/': HTTPSConnection.__init__


Installation of `community.general` is not needed
#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
