### PR TITLE
refactor: add follow=false for recurse option in ansible

### DIFF
--- a/roles/grafana/server/tasks/dashboards.yml
+++ b/roles/grafana/server/tasks/dashboards.yml
@@ -74,6 +74,7 @@
       ansible.builtin.find:
         paths: "{{ grafana_data_dir }}/dashboards"
         recurse: true
+        follow: false
         hidden: true
         patterns:
           - "*.json"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments
With [`follow: false`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/file_module.html#parameter-follow) files related to symlinks do not change permissions. By default, for ansible < 2.5 it is false (we currently use version 2.15), but for versions superior to 2.5 it is set by default to true.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
