### PR TITLE
fix(alloy): fix "observability" alloy pipeline

### DIFF
--- a/tdp_vars_defaults/alloy/alloy_agent.yml
+++ b/tdp_vars_defaults/alloy/alloy_agent.yml
@@ -37,7 +37,7 @@ alloy_pipelines:
         firstline: "{{ alloy_date_regex }}"
     - regex:
         expression: "{{ alloy_log_analyser_regex }}"
-      template:
+    - template:
         source: "level"
         template: "{{ '{{ ToLower (regexReplaceAll \\\"(?i)warn.*\\\" .Value \\\"warning\\\")  }}' }}"
     - timestamp:
@@ -49,11 +49,20 @@ alloy_pipelines:
   observability:
     - logfmt:
         mapping:
-          datetime: "ts"
+          datetime: "t"     # grafana uses t=<datetime>
           level: ""
+    - logfmt:
+        mapping:
+          datetime: "time"  # node_exporter and prometheus use time=<datetime>
+    - logfmt:
+        mapping:
+          datetime: "ts"    # loki and alloy use ts=<datetime>
     - timestamp:
         source: "datetime"
         format: "RFC3339"
+    - template:
+        source: "level"
+        template: "{{ '{{ ToLower (regexReplaceAll \\\"(?i)warn.*\\\" .Value \\\"warning\\\")  }}' }}"
     - labels:
         values:
           level: ""

--- a/tdp_vars_defaults/tdp-cluster/tdp-cluster.yml
+++ b/tdp_vars_defaults/tdp-cluster/tdp-cluster.yml
@@ -122,18 +122,7 @@ observability_tdp_targets:
       group: grafana
       jobs:
         - log_file: "{{ grafana_log_dir }}/{{ grafana_log_file }}"
-          alloy_pipeline:
-            - logfmt:
-                mapping:
-                  datetime: "t"
-                  level: ""
-            - timestamp:
-                source: "datetime"
-                format: "RFC3339"
-            - labels:
-                values:
-                  level: ""
-
+          alloy_pipeline: observability
   exporter:
     unix_group: "{{ node_exporter_group }}"
     node:


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

"observability" alloy pipeline did not work for all log formats from observability  
- alloy and loki use 'ts' keyword for timestamp
- grafana uses 't'
- prometheus uses 'time'
All three keywords are now managed by the alloy pipeline.

Additionaly all levels are lowercased, and "warn" is converted to "warning"


#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
